### PR TITLE
refactor: rename packages to tensor4all-hdf5-ffi and tensor4all-hdf5-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ authors = [
 ]
 keywords = ["hdf5"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/shinaoka/tensor4all-hdf5-ffi"
-homepage = "https://github.com/shinaoka/tensor4all-hdf5-ffi"
+repository = "https://github.com/tensor4all/tensor4all-hdf5-ffi"
+homepage = "https://github.com/tensor4all/tensor4all-hdf5-ffi"
 edition = "2021"
 
 [workspace.dependencies]
@@ -24,8 +24,10 @@ libloading = "0.9"
 num-complex = { version = "0.4", default-features = false }
 
 # internal
-hdf5 = { path = "hdf5" }
-hdf5-types = { path = "hdf5-types" }
+tensor4all-hdf5-ffi = { path = "hdf5" }
+tensor4all-hdf5-types = { path = "hdf5-types" }
+# alias for internal use (to avoid changing source code)
+hdf5-types = { path = "hdf5-types", package = "tensor4all-hdf5-types" }
 
 # Use hdf5-metno-sys from crates.io
 hdf5-sys = { package = "hdf5-metno-sys", version = "0.11" }

--- a/hdf5-types/Cargo.toml
+++ b/hdf5-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hdf5-types"
+name = "tensor4all-hdf5-types"
 description = "Native Rust equivalents of HDF5 types - fork for tensor4all"
 readme = "README.md"
 build = "build.rs"

--- a/hdf5/Cargo.toml
+++ b/hdf5/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hdf5"
+name = "tensor4all-hdf5-ffi"
 readme = "../README.md"
 description = "Thread-safe Rust bindings for the HDF5 library - fork for tensor4all"
 build = "build.rs"

--- a/hdf5/examples/interop_test.rs
+++ b/hdf5/examples/interop_test.rs
@@ -43,7 +43,7 @@ fn main() -> ExitCode {
 
     // Initialize HDF5 with the provided library path
     let lib_path = args.hdf5_lib.to_string_lossy();
-    if let Err(e) = hdf5::sys::init(Some(&lib_path)) {
+    if let Err(e) = tensor4all_hdf5_ffi::sys::init(Some(&lib_path)) {
         eprintln!("Failed to initialize HDF5: {}", e);
         return ExitCode::FAILURE;
     }
@@ -67,9 +67,9 @@ fn main() -> ExitCode {
     }
 }
 
-fn read_test_file(path: &PathBuf) -> hdf5::Result<()> {
-    use hdf5::types::{FixedUnicode, VarLenUnicode};
-    use hdf5::File;
+fn read_test_file(path: &PathBuf) -> tensor4all_hdf5_ffi::Result<()> {
+    use tensor4all_hdf5_ffi::types::{FixedUnicode, VarLenUnicode};
+    use tensor4all_hdf5_ffi::File;
 
     let file = File::open(path)?;
 
@@ -101,7 +101,7 @@ fn read_test_file(path: &PathBuf) -> hdf5::Result<()> {
 
     // Read string dataset (as variable-length unicode strings)
     let ds_str = file.dataset("strings")?;
-    let str_data: Vec<hdf5::types::VarLenUnicode> = ds_str.read_raw()?;
+    let str_data: Vec<tensor4all_hdf5_ffi::types::VarLenUnicode> = ds_str.read_raw()?;
     let str_values: Vec<&str> = str_data.iter().map(|s| s.as_str()).collect();
     assert_eq!(str_values, vec!["foo", "bar", "baz"], "String dataset mismatch");
     println!("  Dataset 'strings': {:?}", str_values);
@@ -109,10 +109,10 @@ fn read_test_file(path: &PathBuf) -> hdf5::Result<()> {
     Ok(())
 }
 
-fn write_test_file(path: &PathBuf) -> hdf5::Result<()> {
-    use hdf5::types::VarLenUnicode;
-    use hdf5::File;
+fn write_test_file(path: &PathBuf) -> tensor4all_hdf5_ffi::Result<()> {
     use std::str::FromStr;
+    use tensor4all_hdf5_ffi::types::VarLenUnicode;
+    use tensor4all_hdf5_ffi::File;
 
     let file = File::create(path)?;
 

--- a/hdf5/tests/common/gen.rs
+++ b/hdf5/tests/common/gen.rs
@@ -2,8 +2,10 @@ use std::convert::TryFrom;
 use std::fmt::{self, Debug};
 use std::iter;
 
-use hdf5::types::{FixedAscii, FixedUnicode, VarLenArray, VarLenAscii, VarLenUnicode};
-use hdf5::H5Type;
+use tensor4all_hdf5_ffi::types::{
+    FixedAscii, FixedUnicode, VarLenArray, VarLenAscii, VarLenUnicode,
+};
+use tensor4all_hdf5_ffi::H5Type;
 
 use half::f16;
 use ndarray::{ArrayD, SliceInfo, SliceInfoElem};

--- a/hdf5/tests/common/util.rs
+++ b/hdf5/tests/common/util.rs
@@ -1,12 +1,14 @@
 use super::gen::gen_ascii;
 
-use hdf5;
+use tensor4all_hdf5_ffi;
 
 pub fn random_filename() -> String {
     gen_ascii(&mut rand::rng(), 8)
 }
 
-pub fn new_in_memory_file() -> hdf5::Result<hdf5::File> {
+pub fn new_in_memory_file() -> tensor4all_hdf5_ffi::Result<tensor4all_hdf5_ffi::File> {
     let filename = random_filename();
-    hdf5::File::with_options().with_fapl(|p| p.core_filebacked(false)).create(&filename)
+    tensor4all_hdf5_ffi::File::with_options()
+        .with_fapl(|p| p.core_filebacked(false))
+        .create(&filename)
 }

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -5,8 +5,8 @@ use std::io::{Read, Seek, SeekFrom};
 use ndarray::{s, Array1, Array2, ArrayD, IxDyn, SliceInfo};
 use rand::prelude::{Rng, SeedableRng, SmallRng};
 
-use hdf5;
-use hdf5_types::TypeDescriptor;
+use tensor4all_hdf5_ffi;
+use tensor4all_hdf5_ffi::types::TypeDescriptor;
 
 mod common;
 
@@ -15,13 +15,13 @@ use self::common::util::new_in_memory_file;
 
 fn test_write_slice<T, R>(
     rng: &mut R,
-    ds: &hdf5::Dataset,
+    ds: &tensor4all_hdf5_ffi::Dataset,
     arr: &ArrayD<T>,
     default_value: &T,
     _ndim: usize,
-) -> hdf5::Result<()>
+) -> tensor4all_hdf5_ffi::Result<()>
 where
-    T: hdf5::H5Type + fmt::Debug + PartialEq + Gen + Clone,
+    T: tensor4all_hdf5_ffi::H5Type + fmt::Debug + PartialEq + Gen + Clone,
     R: Rng + ?Sized,
 {
     let shape = arr.shape();
@@ -48,12 +48,12 @@ where
 
 fn test_read_slice<T, R>(
     rng: &mut R,
-    ds: &hdf5::Dataset,
+    ds: &tensor4all_hdf5_ffi::Dataset,
     arr: &ArrayD<T>,
     ndim: usize,
-) -> hdf5::Result<()>
+) -> tensor4all_hdf5_ffi::Result<()>
 where
-    T: hdf5::H5Type + fmt::Debug + PartialEq + Gen,
+    T: tensor4all_hdf5_ffi::H5Type + fmt::Debug + PartialEq + Gen,
     R: Rng + ?Sized,
 {
     ds.write(arr)?;
@@ -89,7 +89,7 @@ where
     let bad_slice: SliceInfo<_, IxDyn, IxDyn> =
         ndarray::SliceInfo::try_from(bad_slice.as_slice()).unwrap();
 
-    let bad_sliced_read: hdf5::Result<ArrayD<T>> = dsr.read_slice(bad_slice);
+    let bad_sliced_read: tensor4all_hdf5_ffi::Result<ArrayD<T>> = dsr.read_slice(bad_slice);
     assert!(bad_sliced_read.is_err());
 
     // Tests for dimension-dropping slices with static dimensionality.
@@ -113,9 +113,13 @@ where
     Ok(())
 }
 
-fn test_read<T>(ds: &hdf5::Dataset, arr: &ArrayD<T>, ndim: usize) -> hdf5::Result<()>
+fn test_read<T>(
+    ds: &tensor4all_hdf5_ffi::Dataset,
+    arr: &ArrayD<T>,
+    ndim: usize,
+) -> tensor4all_hdf5_ffi::Result<()>
 where
-    T: hdf5::H5Type + fmt::Debug + PartialEq + Gen,
+    T: tensor4all_hdf5_ffi::H5Type + fmt::Debug + PartialEq + Gen,
 {
     ds.write(arr)?;
 
@@ -154,9 +158,13 @@ where
     Ok(())
 }
 
-fn test_write<T>(ds: &hdf5::Dataset, arr: &ArrayD<T>, ndim: usize) -> hdf5::Result<()>
+fn test_write<T>(
+    ds: &tensor4all_hdf5_ffi::Dataset,
+    arr: &ArrayD<T>,
+    ndim: usize,
+) -> tensor4all_hdf5_ffi::Result<()>
 where
-    T: hdf5::H5Type + fmt::Debug + PartialEq + Gen,
+    T: tensor4all_hdf5_ffi::H5Type + fmt::Debug + PartialEq + Gen,
 {
     // .write()
     ds.write(arr)?;
@@ -177,7 +185,11 @@ where
     Ok(())
 }
 
-fn test_byte_read_seek_impl(ds: &hdf5::Dataset, arr: &ArrayD<u8>, ndim: usize) -> hdf5::Result<()> {
+fn test_byte_read_seek_impl(
+    ds: &tensor4all_hdf5_ffi::Dataset,
+    arr: &ArrayD<u8>,
+    ndim: usize,
+) -> tensor4all_hdf5_ffi::Result<()> {
     let mut rng = SmallRng::seed_from_u64(42);
     ds.write(arr)?;
 
@@ -256,9 +268,9 @@ fn test_byte_read_seek_impl(ds: &hdf5::Dataset, arr: &ArrayD<u8>, ndim: usize) -
     Ok(())
 }
 
-fn test_read_write<T>() -> hdf5::Result<()>
+fn test_read_write<T>() -> tensor4all_hdf5_ffi::Result<()>
 where
-    T: hdf5::H5Type + fmt::Debug + PartialEq + Gen + Clone,
+    T: tensor4all_hdf5_ffi::H5Type + fmt::Debug + PartialEq + Gen + Clone,
 {
     let td = T::type_descriptor();
     let mut packed = vec![false];
@@ -275,7 +287,7 @@ where
                 for mode in 0..4 {
                     let arr: ArrayD<T> = gen_arr(&mut rng, ndim);
 
-                    let ds: hdf5::Dataset =
+                    let ds: tensor4all_hdf5_ffi::Dataset =
                         file.new_dataset::<T>().packed(*packed).shape(arr.shape()).create("x")?;
                     let ds = scopeguard::guard(ds, |ds| {
                         drop(ds);
@@ -301,7 +313,7 @@ where
 }
 
 #[test]
-fn test_read_write_primitive() -> hdf5::Result<()> {
+fn test_read_write_primitive() -> tensor4all_hdf5_ffi::Result<()> {
     test_read_write::<i8>()?;
     test_read_write::<i16>()?;
     test_read_write::<i32>()?;
@@ -318,14 +330,14 @@ fn test_read_write_primitive() -> hdf5::Result<()> {
 
 #[cfg(feature = "f16")]
 #[test]
-fn test_read_write_f16() -> hdf5::Result<()> {
+fn test_read_write_f16() -> tensor4all_hdf5_ffi::Result<()> {
     test_read_write::<::half::f16>()?;
     Ok(())
 }
 
 #[cfg(feature = "complex")]
 #[test]
-fn test_read_write_complex() -> hdf5::Result<()> {
+fn test_read_write_complex() -> tensor4all_hdf5_ffi::Result<()> {
     test_read_write::<::num_complex::Complex32>()?;
     test_read_write::<::num_complex::Complex64>()?;
     Ok(())
@@ -342,7 +354,7 @@ fn test_create_on_databuilder() {
 }
 
 #[test]
-fn test_byte_read_seek() -> hdf5::Result<()> {
+fn test_byte_read_seek() -> tensor4all_hdf5_ffi::Result<()> {
     let mut rng = SmallRng::seed_from_u64(42);
     let file = new_in_memory_file()?;
 
@@ -350,7 +362,8 @@ fn test_byte_read_seek() -> hdf5::Result<()> {
         for _ in 0..=20 {
             let arr: ArrayD<u8> = gen_arr(&mut rng, ndim);
 
-            let ds: hdf5::Dataset = file.new_dataset::<u8>().shape(arr.shape()).create("x")?;
+            let ds: tensor4all_hdf5_ffi::Dataset =
+                file.new_dataset::<u8>().shape(arr.shape()).create("x")?;
             let ds = scopeguard::guard(ds, |ds| {
                 drop(ds);
                 drop(file.unlink("x"));


### PR DESCRIPTION
## Summary

- Rename `hdf5` package to `tensor4all-hdf5-ffi`
- Rename `hdf5-types` package to `tensor4all-hdf5-types`
- Update workspace.dependencies with proper aliases for internal use
- Update all test/example references to use new package names
- Update repository URLs to tensor4all organization

This enables tensor4all-rs to use this repository as a git dependency with consistent naming.

## Related

- tensor4all/tensor4all-rs#211

🤖 Generated with [Claude Code](https://claude.com/claude-code)