### PR TITLE
fix: resolve clippy errors for conditional compilation

### DIFF
--- a/hdf5-types/Cargo.toml
+++ b/hdf5-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "tensor4all-hdf5-types"
 description = "Native Rust equivalents of HDF5 types - fork for tensor4all"
 readme = "README.md"
 build = "build.rs"
+links = "hdf5_types"
 categories = ["encoding"]
 version = "0.1.0"
 rust-version.workspace = true

--- a/hdf5-types/build.rs
+++ b/hdf5-types/build.rs
@@ -13,6 +13,8 @@ fn main() {
         if key.starts_with("DEP_HDF5_VERSION_") {
             let version = key.trim_start_matches("DEP_HDF5_VERSION_").replace("_", ".");
             println!("cargo::rustc-cfg=feature=\"{version}\"");
+            // Re-export version metadata for dependent crates (e.g., hdf5 in runtime-loading mode)
+            println!("cargo::metadata=VERSION_{version}=1");
         }
     }
 }

--- a/hdf5/build.rs
+++ b/hdf5/build.rs
@@ -47,9 +47,13 @@ fn main() {
             "DEP_HDF5_HAVE_FILTER_DEFLATE" => print_feature("have-filter-deflate"),
             // internal config flags
             "DEP_HDF5_MSVC_DLL_INDIRECTION" => print_cfg("msvc_dll_indirection"),
-            // public version features
+            // public version features (from hdf5-sys directly)
             key if key.starts_with("DEP_HDF5_VERSION_") => {
                 print_feature(&key.trim_start_matches("DEP_HDF5_VERSION_").replace('_', "."));
+            }
+            // public version features (from hdf5-types, for runtime-loading mode)
+            key if key.starts_with("DEP_HDF5_TYPES_VERSION_") => {
+                print_feature(&key.trim_start_matches("DEP_HDF5_TYPES_VERSION_").replace('_', "."));
             }
             _ => continue,
         }

--- a/hdf5/src/hl/datatype.rs
+++ b/hdf5/src/hl/datatype.rs
@@ -446,10 +446,6 @@ impl Datatype {
                 TD::Reference(hdf5_types::Reference::Std) => {
                     Ok(h5try!(H5Tcopy(*crate::globals::H5T_STD_REF)))
                 }
-                #[cfg(not(feature = "1.12.0"))]
-                TD::Reference(hdf5_types::Reference::Std) => {
-                    Err("Reference::Std requires HDF5 1.12.0 or later".into())
-                }
                 TD::Reference(hdf5_types::Reference::Object) => {
                     Ok(h5try!(H5Tcopy(*crate::globals::H5T_STD_REF_OBJ)))
                 }

--- a/hdf5/src/hl/references.rs
+++ b/hdf5/src/hl/references.rs
@@ -51,10 +51,11 @@ impl ReferencedObject {
             H5O_TYPE_GROUP => ReferencedObject::Group(Group::from_id(object_id)?),
             H5O_TYPE_DATASET => ReferencedObject::Dataset(Dataset::from_id(object_id)?),
             H5O_TYPE_NAMED_DATATYPE => ReferencedObject::Datatype(Datatype::from_id(object_id)?),
-            #[cfg(feature = "1.12.0")]
+            #[cfg(any(
+                feature = "1.12.0",
+                all(feature = "runtime-loading", not(feature = "link"))
+            ))]
             H5O_TYPE_MAP => fail!("Can not create object from a map"),
-            #[cfg(not(feature = "1.12.0"))]
-            H5O_TYPE_MAP => fail!("Map objects require HDF5 1.12.0 or later"),
             H5O_TYPE_UNKNOWN => fail!("Unknown datatype"),
             H5O_TYPE_NTYPES => fail!("hdf5 should not produce this type"),
         };


### PR DESCRIPTION
## Summary
- Remove unreachable match arms for `Reference::Std` when `1.12.0` feature is not enabled
- Fix `H5O_TYPE_MAP` match arm to use proper feature gating
- Add `links` metadata to hdf5-types to propagate version info to dependent crates
- Update hdf5 build.rs to read version metadata from hdf5-types

## Test plan
- [x] `cargo clippy --workspace` passes
- [x] `cargo test --workspace` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)