### PR TITLE
fix: disable version-gated APIs in runtime-loading mode

### DIFF
--- a/hdf5/src/hl/chunks.rs
+++ b/hdf5/src/hl/chunks.rs
@@ -67,7 +67,7 @@ pub(crate) fn get_num_chunks(ds: &Dataset) -> Option<usize> {
     }))
 }
 
-#[cfg(feature = "1.14.0")]
+#[cfg(all(feature = "1.14.0", feature = "link"))]
 mod v1_14_0 {
     use super::*;
     use crate::sys::h5d::H5Dchunk_iter;
@@ -182,5 +182,5 @@ mod v1_14_0 {
         }
     }
 }
-#[cfg(feature = "1.14.0")]
+#[cfg(all(feature = "1.14.0", feature = "link"))]
 pub use v1_14_0::*;

--- a/hdf5/src/hl/dataset.rs
+++ b/hdf5/src/hl/dataset.rs
@@ -10,10 +10,10 @@ use crate::hl;
 #[cfg(feature = "blosc")]
 use crate::hl::filters::{Blosc, BloscShuffle};
 use crate::hl::filters::{Filter, SZip, ScaleOffset};
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 use crate::hl::plist::dataset_access::VirtualView;
 use crate::hl::plist::dataset_access::{DatasetAccess, DatasetAccessBuilder};
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 use crate::hl::plist::dataset_create::ChunkOpts;
 use crate::hl::plist::dataset_create::{
     AllocTime, AttrCreationOrder, DatasetCreate, DatasetCreateBuilder, FillTime, Layout,
@@ -25,7 +25,7 @@ use crate::sys::h5d::{
     H5Dcreate2, H5Dcreate_anon, H5Dget_access_plist, H5Dget_create_plist, H5Dget_offset,
     H5Dset_extent,
 };
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 use crate::sys::h5d::{H5Dflush, H5Drefresh};
 use crate::sys::h5l::H5Ldelete;
 use crate::sys::h5p::H5P_DEFAULT;
@@ -123,7 +123,7 @@ impl Dataset {
     }
 
     /// Visit all chunks
-    #[cfg(feature = "1.14.0")]
+    #[cfg(all(feature = "1.14.0", feature = "link"))]
     pub fn chunks_visit<F>(&self, callback: F) -> Result<()>
     where
         F: for<'a> FnMut(crate::dataset::ChunkInfoRef<'a>) -> i32,
@@ -161,7 +161,7 @@ impl Dataset {
     }
 
     /// Flush the dataset metadata from the metadata cache to the file
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn flush(&self) -> Result<()> {
         let id = self.id();
         h5call!(H5Dflush(id))?;
@@ -169,7 +169,7 @@ impl Dataset {
     }
 
     /// Refresh metadata items assosicated with the dataset
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn refresh(&self) -> Result<()> {
         let id = self.id();
         h5call!(H5Drefresh(id))?;
@@ -621,12 +621,12 @@ impl DatasetBuilderInner {
         self.with_dapl(|pl| pl.efile_prefix(prefix));
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_view(&mut self, view: VirtualView) {
         self.with_dapl(|pl| pl.virtual_view(view));
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_printf_gap(&mut self, gap_size: usize) {
         self.with_dapl(|pl| pl.virtual_printf_gap(gap_size));
     }
@@ -823,7 +823,7 @@ impl DatasetBuilderInner {
         self.with_dcpl(|pl| pl.layout(layout));
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn chunk_opts(&mut self, opts: ChunkOpts) {
         self.with_dcpl(|pl| pl.chunk_opts(opts));
     }
@@ -832,7 +832,7 @@ impl DatasetBuilderInner {
         self.with_dcpl(|pl| pl.external(name, offset, size));
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_map<F, D, E1, S1, E2, S2>(
         &mut self,
         src_filename: F,
@@ -1002,8 +1002,8 @@ macro_rules! impl_builder_methods {
 
         impl_builder!(DatasetAccess: chunk_cache(nslots: usize, nbytes: usize, w0: f64));
         impl_builder!(#[cfg(feature = "1.8.17")] DatasetAccess: efile_prefix(prefix: &str));
-        impl_builder!(#[cfg(feature = "1.10.0")] DatasetAccess: virtual_view(view: VirtualView));
-        impl_builder!(#[cfg(feature = "1.10.0")] DatasetAccess: virtual_printf_gap(gap_size: usize));
+        impl_builder!(#[cfg(all(feature = "1.10.0", feature = "link"))] DatasetAccess: virtual_view(view: VirtualView));
+        impl_builder!(#[cfg(all(feature = "1.10.0", feature = "link"))] DatasetAccess: virtual_printf_gap(gap_size: usize));
         impl_builder!(
             #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
             DatasetAccess: all_coll_metadata_ops(is_collective: bool)
@@ -1076,10 +1076,10 @@ macro_rules! impl_builder_methods {
         impl_builder!(*: chunk_min_kb(size: usize));
         impl_builder!(DatasetCreate: no_chunk());
         impl_builder!(DatasetCreate: layout(layout: Layout));
-        impl_builder!(#[cfg(feature = "1.10.0")] DatasetCreate: chunk_opts(opts: ChunkOpts));
+        impl_builder!(#[cfg(all(feature = "1.10.0", feature = "link"))] DatasetCreate: chunk_opts(opts: ChunkOpts));
         impl_builder!(DatasetCreate: external(name: &str, offset: usize, size: usize));
         impl_builder!(
-            #[cfg(feature = "1.10.0")]
+            #[cfg(all(feature = "1.10.0", feature = "link"))]
             DatasetCreate: virtual_map<
                 F: AsRef<str>, D: AsRef<str>,
                 E1: Into<Extents>, S1: Into<Selection>, E2: Into<Extents>, S2: Into<Selection>

--- a/hdf5/src/hl/plist/dataset_access.rs
+++ b/hdf5/src/hl/plist/dataset_access.rs
@@ -13,7 +13,7 @@ use crate::sys::h5p::{H5Pcreate, H5Pget_chunk_cache, H5Pset_chunk_cache};
 use crate::sys::h5p::{H5Pget_all_coll_metadata_ops, H5Pset_all_coll_metadata_ops};
 #[cfg(feature = "1.8.17")]
 use crate::sys::h5p::{H5Pget_efile_prefix, H5Pset_efile_prefix};
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 use crate::sys::{
     h5d::H5D_vds_view_t,
     h5p::{
@@ -58,7 +58,7 @@ impl Debug for DatasetAccess {
         formatter.field("chunk_cache", &self.chunk_cache());
         #[cfg(feature = "1.8.17")]
         formatter.field("efile_prefix", &self.efile_prefix());
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         {
             formatter.field("virtual_view", &self.virtual_view());
             formatter.field("virtual_printf_gap", &self.virtual_printf_gap());
@@ -92,7 +92,7 @@ impl Clone for DatasetAccess {
 }
 
 /// Options for including or excluding missing mapped elements in a virtual dataset view.
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VirtualView {
     /// Include all data before the first missing mapped data.
@@ -101,14 +101,14 @@ pub enum VirtualView {
     LastAvailable,
 }
 
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 impl Default for VirtualView {
     fn default() -> Self {
         Self::LastAvailable
     }
 }
 
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 impl From<H5D_vds_view_t> for VirtualView {
     fn from(view: H5D_vds_view_t) -> Self {
         match view {
@@ -118,7 +118,7 @@ impl From<H5D_vds_view_t> for VirtualView {
     }
 }
 
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 impl From<VirtualView> for H5D_vds_view_t {
     fn from(v: VirtualView) -> Self {
         match v {
@@ -134,9 +134,9 @@ pub struct DatasetAccessBuilder {
     chunk_cache: Option<ChunkCache>,
     #[cfg(feature = "1.8.17")]
     efile_prefix: Option<String>,
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     virtual_view: Option<VirtualView>,
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     virtual_printf_gap: Option<usize>,
     #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
     all_coll_metadata_ops: Option<bool>,
@@ -158,7 +158,7 @@ impl DatasetAccessBuilder {
             let v = plist.get_efile_prefix()?;
             builder.efile_prefix(&v);
         }
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         {
             builder.virtual_view(plist.get_virtual_view()?);
             builder.virtual_printf_gap(plist.get_virtual_printf_gap()?);
@@ -182,7 +182,7 @@ impl DatasetAccessBuilder {
     }
 
     /// Sets the [`VirtualView`] options.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_view(&mut self, view: VirtualView) -> &mut Self {
         self.virtual_view = Some(view);
         self
@@ -190,7 +190,7 @@ impl DatasetAccessBuilder {
 
     /// Sets the maximum number of files/datasets allowed to be missing when determining the extent
     /// of an unlimited virtual dataset with printf-style mappings.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_printf_gap(&mut self, gap_size: usize) -> &mut Self {
         self.virtual_printf_gap = Some(gap_size);
         self
@@ -214,7 +214,7 @@ impl DatasetAccessBuilder {
                 h5try!(H5Pset_efile_prefix(id, v.as_ptr()));
             }
         }
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         {
             if let Some(v) = self.virtual_view {
                 h5try!(H5Pset_virtual_view(id, v.into()));
@@ -291,19 +291,19 @@ impl DatasetAccess {
         self.get_efile_prefix().ok().unwrap_or_default()
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     #[doc(hidden)]
     pub fn get_virtual_view(&self) -> Result<VirtualView> {
         h5get!(H5Pget_virtual_view(self.id()): H5D_vds_view_t).map(Into::into)
     }
 
     /// Returns the virtual dataset view options.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_view(&self) -> VirtualView {
         self.get_virtual_view().ok().unwrap_or_default()
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     #[doc(hidden)]
     pub fn get_virtual_printf_gap(&self) -> Result<usize> {
         h5get!(H5Pget_virtual_printf_gap(self.id()): hsize_t).map(|x| x as _)
@@ -311,7 +311,7 @@ impl DatasetAccess {
 
     /// Returns the maximum number of files/datasets allowed to be missing when determining the
     /// extent of an unlimited virtual dataset with printf-style mappings.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_printf_gap(&self) -> usize {
         self.get_virtual_printf_gap().unwrap_or(0)
     }

--- a/hdf5/src/hl/plist/dataset_create.rs
+++ b/hdf5/src/hl/plist/dataset_create.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug};
 use std::ops::Deref;
 use std::ptr::{self, addr_of_mut};
 
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 use bitflags::bitflags;
 
 use crate::sys::h5d::{H5D_alloc_time_t, H5D_fill_time_t, H5D_fill_value_t, H5D_layout_t};
@@ -19,7 +19,7 @@ use crate::sys::h5p::{
 };
 use crate::sys::h5t::H5Tget_class;
 use crate::sys::h5z::H5Z_filter_t;
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 use crate::sys::{
     h5d::H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS,
     h5p::{
@@ -74,10 +74,10 @@ impl Debug for DatasetCreate {
         formatter.field("fill_value", &self.fill_value_defined());
         formatter.field("chunk", &self.chunk());
         formatter.field("layout", &self.layout());
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         formatter.field("chunk_opts", &self.chunk_opts());
         formatter.field("external", &self.external());
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         formatter.field("virtual_map", &self.virtual_map());
         formatter.field("obj_track_times", &self.obj_track_times());
         formatter.field("attr_phase_change", &self.attr_phase_change());
@@ -118,7 +118,7 @@ pub enum Layout {
     /// Raw data is stored in separate chunks in the file.
     Chunked,
     /// Raw data is drawn from multiple datasets in different files.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     Virtual,
 }
 
@@ -133,7 +133,7 @@ impl From<H5D_layout_t> for Layout {
         match layout {
             H5D_layout_t::H5D_COMPACT => Self::Compact,
             H5D_layout_t::H5D_CHUNKED => Self::Chunked,
-            #[cfg(feature = "1.10.0")]
+            #[cfg(all(feature = "1.10.0", feature = "link"))]
             H5D_layout_t::H5D_VIRTUAL => Self::Virtual,
             _ => Self::Contiguous,
         }
@@ -145,14 +145,14 @@ impl From<Layout> for H5D_layout_t {
         match layout {
             Layout::Compact => Self::H5D_COMPACT,
             Layout::Chunked => Self::H5D_CHUNKED,
-            #[cfg(feature = "1.10.0")]
+            #[cfg(all(feature = "1.10.0", feature = "link"))]
             Layout::Virtual => Self::H5D_VIRTUAL,
             Layout::Contiguous => Self::H5D_CONTIGUOUS,
         }
     }
 }
 
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 bitflags! {
     /// Edge chunk option flags.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -162,7 +162,7 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 impl Default for ChunkOpts {
     fn default() -> Self {
         Self::DONT_FILTER_PARTIAL_CHUNKS
@@ -287,7 +287,7 @@ pub struct ExternalFile {
 }
 
 /// Properties of a mapping between virtual and source datasets.
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VirtualMapping {
     /// The name of the HDF5 file containing the source dataset.
@@ -304,7 +304,7 @@ pub struct VirtualMapping {
     pub vds_selection: Selection,
 }
 
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 impl VirtualMapping {
     /// Constructs a `VirtualMapping` with the given parameters.
     pub fn new<F, D, E1, S1, E2, S2>(
@@ -344,10 +344,10 @@ pub struct DatasetCreateBuilder {
     fill_value: Option<OwnedDynValue>,
     chunk: Option<Vec<usize>>,
     layout: Option<Layout>,
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     chunk_opts: Option<ChunkOpts>,
     external: Vec<ExternalFile>,
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     virtual_map: Vec<VirtualMapping>,
     obj_track_times: Option<bool>,
     attr_phase_change: Option<AttrPhaseChange>,
@@ -374,7 +374,7 @@ impl DatasetCreateBuilder {
         }
         let layout = plist.get_layout()?;
         builder.layout(layout);
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         {
             if let Some(v) = plist.get_chunk_opts()? {
                 builder.chunk_opts(v);
@@ -625,7 +625,7 @@ impl DatasetCreateBuilder {
     }
 
     /// Sets the dataset's edge chunk options.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn chunk_opts(&mut self, opts: ChunkOpts) -> &mut Self {
         self.chunk_opts = Some(opts);
         self
@@ -638,7 +638,7 @@ impl DatasetCreateBuilder {
     }
 
     /// Adds a mapping between virtual and source datasets.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_map<F, D, E1, S1, E2, S2>(
         &mut self,
         src_filename: F,
@@ -710,7 +710,7 @@ impl DatasetCreateBuilder {
             let v = v.iter().map(|&x| x as _).collect::<Vec<_>>();
             h5try!(H5Pset_chunk(id, v.len() as _, v.as_ptr()));
         }
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         {
             if let Some(v) = self.chunk_opts {
                 h5try!(H5Pset_chunk_opts(id, v.bits() as _));
@@ -902,7 +902,7 @@ impl DatasetCreate {
         self.get_layout().unwrap_or_default()
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     #[doc(hidden)]
     pub fn get_chunk_opts(&self) -> Result<Option<ChunkOpts>> {
         if self.get_layout()? == Layout::Chunked {
@@ -914,7 +914,7 @@ impl DatasetCreate {
     }
 
     /// Returns the edge chunk option setting, or `None` if the dataset is not chunked.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn chunk_opts(&self) -> Option<ChunkOpts> {
         self.get_chunk_opts().unwrap_or_default()
     }
@@ -953,7 +953,7 @@ impl DatasetCreate {
         self.get_external().unwrap_or_default()
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     #[doc(hidden)]
     pub fn get_virtual_map(&self) -> Result<Vec<VirtualMapping>> {
         sync(|| unsafe {
@@ -990,7 +990,7 @@ impl DatasetCreate {
     }
 
     /// Returns a vector of virtual mapping specifiers for the dataset.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn virtual_map(&self) -> Vec<VirtualMapping> {
         self.get_virtual_map().unwrap_or_default()
     }

--- a/hdf5/src/hl/plist/file_access.rs
+++ b/hdf5/src/hl/plist/file_access.rs
@@ -47,9 +47,9 @@ use crate::sys::h5p::{H5Pget_fapl_direct, H5Pset_fapl_direct};
 #[cfg(feature = "mpio")]
 use crate::sys::h5p::{H5Pget_fapl_mpio, H5Pset_fapl_mpio};
 
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 use crate::sys::h5ac::{H5AC_cache_image_config_t, H5AC__CACHE_IMAGE__ENTRY_AGEOUT__NONE};
-#[cfg(feature = "1.10.2")]
+#[cfg(all(feature = "1.10.2", feature = "link"))]
 use crate::sys::h5f::H5F_libver_t;
 #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
 use crate::sys::h5p::{
@@ -60,14 +60,14 @@ use crate::sys::h5p::{
 use crate::sys::h5p::{H5Pget_core_write_tracking, H5Pset_core_write_tracking};
 #[cfg(feature = "1.8.7")]
 use crate::sys::h5p::{H5Pget_elink_file_cache_size, H5Pset_elink_file_cache_size};
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 use crate::sys::h5p::{
     H5Pget_evict_on_close, H5Pget_mdc_image_config, H5Pget_page_buffer_size, H5Pset_evict_on_close,
     H5Pset_mdc_image_config, H5Pset_page_buffer_size,
 };
-#[cfg(feature = "1.10.2")]
+#[cfg(all(feature = "1.10.2", feature = "link"))]
 use crate::sys::h5p::{H5Pget_libver_bounds, H5Pset_libver_bounds};
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 use crate::sys::h5p::{
     H5Pget_mdc_log_options, H5Pget_metadata_read_attempts, H5Pset_mdc_log_options,
     H5Pset_metadata_read_attempts,
@@ -116,21 +116,21 @@ impl Debug for FileAccess {
         formatter.field("fclose_degree", &self.fclose_degree());
         formatter.field("gc_references", &self.gc_references());
         formatter.field("small_data_block_size", &self.small_data_block_size());
-        #[cfg(feature = "1.10.2")]
+        #[cfg(all(feature = "1.10.2", feature = "link"))]
         formatter.field("libver_bounds", &self.libver_bounds());
         #[cfg(feature = "1.8.7")]
         formatter.field("elink_file_cache_size", &self.elink_file_cache_size());
         formatter.field("meta_block_size", &self.meta_block_size());
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         formatter.field("page_buffer_size", &self.page_buffer_size());
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         formatter.field("evict_on_close", &self.evict_on_close());
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         formatter.field("mdc_image_config", &self.mdc_image_config());
         formatter.field("sieve_buf_size", &self.sieve_buf_size());
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         formatter.field("metadata_read_attempts", &self.metadata_read_attempts());
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         formatter.field("mdc_log_options", &self.mdc_log_options());
         #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
         formatter.field("all_coll_metadata_ops", &self.all_coll_metadata_ops());
@@ -964,7 +964,7 @@ impl From<H5AC_cache_config_t> for MetadataCacheConfig {
     }
 }
 
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 mod cache_image_config {
     use super::*;
 
@@ -1012,11 +1012,11 @@ mod cache_image_config {
     }
 }
 
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 pub use self::cache_image_config::*;
 
 /// Metadata cache logging options.
-#[cfg(feature = "1.10.0")]
+#[cfg(all(feature = "1.10.0", feature = "link"))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CacheLogOptions {
     /// Whether logging is enabled.
@@ -1027,7 +1027,7 @@ pub struct CacheLogOptions {
     pub start_on_access: bool,
 }
 
-#[cfg(feature = "1.10.2")]
+#[cfg(all(feature = "1.10.2", feature = "link"))]
 mod libver {
     use super::*;
 
@@ -1102,7 +1102,7 @@ mod libver {
     }
 }
 
-#[cfg(feature = "1.10.2")]
+#[cfg(all(feature = "1.10.2", feature = "link"))]
 pub use self::libver::*;
 
 /// Builder used to create file access property list.
@@ -1118,17 +1118,17 @@ pub struct FileAccessBuilder {
     #[cfg(feature = "1.8.7")]
     elink_file_cache_size: Option<u32>,
     meta_block_size: Option<u64>,
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     page_buffer_size: Option<PageBufferSize>,
     sieve_buf_size: Option<usize>,
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     evict_on_close: Option<bool>,
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     metadata_read_attempts: Option<u32>,
     mdc_config: Option<MetadataCacheConfig>,
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     mdc_image_config: Option<CacheImageConfig>,
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     mdc_log_options: Option<CacheLogOptions>,
     #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
     all_coll_metadata_ops: Option<bool>,
@@ -1136,7 +1136,7 @@ pub struct FileAccessBuilder {
     coll_metadata_write: Option<bool>,
     gc_references: Option<bool>,
     small_data_block_size: Option<u64>,
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     libver_bounds: Option<LibVerBounds>,
 }
 
@@ -1158,7 +1158,7 @@ impl FileAccessBuilder {
         builder.driver(&drv);
         builder.gc_references(plist.get_gc_references()?);
         builder.small_data_block_size(plist.get_small_data_block_size()?);
-        #[cfg(feature = "1.10.2")]
+        #[cfg(all(feature = "1.10.2", feature = "link"))]
         {
             let v = plist.get_libver_bounds()?;
             builder.libver_bounds(v.low, v.high);
@@ -1168,7 +1168,7 @@ impl FileAccessBuilder {
             builder.elink_file_cache_size(plist.get_elink_file_cache_size()?);
         }
         builder.meta_block_size(plist.get_meta_block_size()?);
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         {
             let v = plist.get_page_buffer_size()?;
             builder.page_buffer_size(v.buf_size, v.min_meta_perc, v.min_raw_perc);
@@ -1176,7 +1176,7 @@ impl FileAccessBuilder {
             builder.mdc_image_config(plist.get_mdc_image_config()?.generate_image);
         }
         builder.sieve_buf_size(plist.get_sieve_buf_size()?);
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         {
             builder.metadata_read_attempts(plist.get_metadata_read_attempts()?);
             let v = plist.get_mdc_log_options()?;
@@ -1233,7 +1233,7 @@ impl FileAccessBuilder {
     }
 
     /// Sets the page buffer size properties.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn page_buffer_size(
         &mut self,
         buf_size: usize,
@@ -1251,7 +1251,7 @@ impl FileAccessBuilder {
     }
 
     /// Sets whether object metadata should be evicted from cache when an object is closed.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn evict_on_close(&mut self, evict_on_close: bool) -> &mut Self {
         self.evict_on_close = Some(evict_on_close);
         self
@@ -1259,7 +1259,7 @@ impl FileAccessBuilder {
 
     /// Sets the number of reads that the library will try when reading checksummed metadata in a
     /// file opened with SWMR access.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn metadata_read_attempts(&mut self, attempts: u32) -> &mut Self {
         self.metadata_read_attempts = Some(attempts);
         self
@@ -1272,7 +1272,7 @@ impl FileAccessBuilder {
     }
 
     /// Sets whether a cache image should be created on file close.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn mdc_image_config(&mut self, generate_image: bool) -> &mut Self {
         self.mdc_image_config = Some(CacheImageConfig {
             generate_image,
@@ -1283,7 +1283,7 @@ impl FileAccessBuilder {
     }
 
     /// Sets metadata cache logging options.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn mdc_log_options(
         &mut self,
         is_enabled: bool,
@@ -1322,32 +1322,32 @@ impl FileAccessBuilder {
     }
 
     /// Sets the range of library versions to use when writing objects.
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     pub fn libver_bounds(&mut self, low: LibraryVersion, high: LibraryVersion) -> &mut Self {
         self.libver_bounds = Some(LibVerBounds { low, high });
         self
     }
 
     /// Allows use of the earliest library version when writing objects.
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     pub fn libver_earliest(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::Earliest, LibraryVersion::latest())
     }
 
     /// Sets the earliest library version for writing objects to v18.
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     pub fn libver_v18(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::V18, LibraryVersion::latest())
     }
 
     /// Sets the earliest library version for writing objects to v110.
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     pub fn libver_v110(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::V110, LibraryVersion::latest())
     }
 
     /// Allows only the latest library version when writing objects.
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     pub fn libver_latest(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::latest(), LibraryVersion::latest())
     }
@@ -1639,7 +1639,7 @@ impl FileAccessBuilder {
         if let Some(v) = self.small_data_block_size {
             h5try!(H5Pset_small_data_block_size(id, v as _));
         }
-        #[cfg(feature = "1.10.2")]
+        #[cfg(all(feature = "1.10.2", feature = "link"))]
         {
             if let Some(v) = self.libver_bounds {
                 h5try!(H5Pset_libver_bounds(id, v.low.into(), v.high.into()));
@@ -1654,7 +1654,7 @@ impl FileAccessBuilder {
         if let Some(v) = self.meta_block_size {
             h5try!(H5Pset_meta_block_size(id, v as _));
         }
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         {
             if let Some(v) = self.page_buffer_size {
                 h5try!(H5Pset_page_buffer_size(
@@ -1680,7 +1680,7 @@ impl FileAccessBuilder {
         if let Some(v) = self.sieve_buf_size {
             h5try!(H5Pset_sieve_buf_size(id, v as _));
         }
-        #[cfg(feature = "1.10.0")]
+        #[cfg(all(feature = "1.10.0", feature = "link"))]
         {
             if let Some(v) = self.metadata_read_attempts {
                 h5try!(H5Pset_metadata_read_attempts(id, v as _));
@@ -1936,7 +1936,7 @@ impl FileAccess {
         self.get_meta_block_size().unwrap_or(2048)
     }
 
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     #[doc(hidden)]
     pub fn get_page_buffer_size(&self) -> Result<PageBufferSize> {
         h5get!(H5Pget_page_buffer_size(self.id()): size_t, c_uint, c_uint).map(
@@ -1949,7 +1949,7 @@ impl FileAccess {
     }
 
     /// Returns the page buffer size properties.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn page_buffer_size(&self) -> PageBufferSize {
         self.get_page_buffer_size().unwrap_or_else(|_| PageBufferSize::default())
     }
@@ -1964,7 +1964,7 @@ impl FileAccess {
         self.get_sieve_buf_size().unwrap_or(64 * 1024)
     }
 
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     #[doc(hidden)]
     pub fn get_evict_on_close(&self) -> Result<bool> {
         h5get!(H5Pget_evict_on_close(self.id()): hbool_t).map(|x| x > 0)
@@ -1972,19 +1972,19 @@ impl FileAccess {
 
     /// Returns `true` if an object will be evicted from the metadata cache when the object is
     /// closed.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn evict_on_close(&self) -> bool {
         self.get_evict_on_close().unwrap_or(false)
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     #[doc(hidden)]
     pub fn get_metadata_read_attempts(&self) -> Result<u32> {
         h5get!(H5Pget_metadata_read_attempts(self.id()): c_uint).map(|x| x as _)
     }
 
     /// Returns the number of read attempts for SWMR access.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn metadata_read_attempts(&self) -> u32 {
         self.get_metadata_read_attempts().unwrap_or(1)
     }
@@ -2001,7 +2001,7 @@ impl FileAccess {
         self.get_mdc_config().ok().unwrap_or_default()
     }
 
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     #[doc(hidden)]
     pub fn get_mdc_image_config(&self) -> Result<CacheImageConfig> {
         let mut config: H5AC_cache_image_config_t = unsafe { mem::zeroed() };
@@ -2010,12 +2010,12 @@ impl FileAccess {
     }
 
     /// Returns the metadata cache image configuration.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn mdc_image_config(&self) -> CacheImageConfig {
         self.get_mdc_image_config().ok().unwrap_or_default()
     }
 
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     #[doc(hidden)]
     #[allow(clippy::unnecessary_cast)]
     pub fn get_mdc_log_options(&self) -> Result<CacheLogOptions> {
@@ -2046,7 +2046,7 @@ impl FileAccess {
     }
 
     /// Returns the metadata cache logging options.
-    #[cfg(feature = "1.10.0")]
+    #[cfg(all(feature = "1.10.0", feature = "link"))]
     pub fn mdc_log_options(&self) -> CacheLogOptions {
         self.get_mdc_log_options().ok().unwrap_or_default()
     }
@@ -2095,7 +2095,7 @@ impl FileAccess {
         self.get_small_data_block_size().unwrap_or(2048)
     }
 
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     #[doc(hidden)]
     pub fn get_libver_bounds(&self) -> Result<LibVerBounds> {
         h5get!(H5Pget_libver_bounds(self.id()): H5F_libver_t, H5F_libver_t)
@@ -2103,13 +2103,13 @@ impl FileAccess {
     }
 
     /// Returns the library format version bounds for writing objects to a file.
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     pub fn libver_bounds(&self) -> LibVerBounds {
         self.get_libver_bounds().ok().unwrap_or_default()
     }
 
     /// Returns the lower library format version bound for writing objects to a file.
-    #[cfg(feature = "1.10.2")]
+    #[cfg(all(feature = "1.10.2", feature = "link"))]
     pub fn libver(&self) -> LibraryVersion {
         self.get_libver_bounds().ok().unwrap_or_default().low
     }

--- a/hdf5/src/hl/plist/file_create.rs
+++ b/hdf5/src/hl/plist/file_create.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 use bitflags::bitflags;
 
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 use crate::sys::h5f::H5F_fspace_strategy_t;
 use crate::sys::h5o::{
     H5O_SHMESG_ALL_FLAG, H5O_SHMESG_ATTR_FLAG, H5O_SHMESG_DTYPE_FLAG, H5O_SHMESG_FILL_FLAG,
@@ -19,7 +19,7 @@ use crate::sys::h5p::{
     H5Pset_shared_mesg_index, H5Pset_shared_mesg_nindexes, H5Pset_shared_mesg_phase_change,
     H5Pset_sym_k, H5Pset_userblock,
 };
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 use crate::sys::h5p::{
     H5Pget_file_space_page_size, H5Pget_file_space_strategy, H5Pset_file_space_page_size,
     H5Pset_file_space_strategy,
@@ -68,7 +68,7 @@ impl Debug for FileCreate {
         formatter.field("obj_track_times", &self.obj_track_times());
         formatter.field("attr_phase_change", &self.attr_phase_change());
         formatter.field("attr_creation_order", &self.attr_creation_order());
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         {
             formatter.field("file_space_page_size", &self.file_space_page_size());
             formatter.field("file_space_strategy", &self.file_space_strategy());
@@ -190,7 +190,7 @@ pub struct SharedMessageIndex {
 }
 
 /// File space handling strategy.
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum FileSpaceStrategy {
     /// Mechanisms used: free-space managers, aggregators or embedded paged
@@ -209,7 +209,7 @@ pub enum FileSpaceStrategy {
     None,
 }
 
-#[cfg(feature = "1.10.1")]
+#[cfg(all(feature = "1.10.1", feature = "link"))]
 impl Default for FileSpaceStrategy {
     fn default() -> Self {
         Self::FreeSpaceManager { paged: false, persist: false, threshold: 1 }
@@ -227,9 +227,9 @@ pub struct FileCreateBuilder {
     obj_track_times: Option<bool>,
     attr_phase_change: Option<AttrPhaseChange>,
     attr_creation_order: Option<AttrCreationOrder>,
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     file_space_page_size: Option<u64>,
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     file_space_strategy: Option<FileSpaceStrategy>,
 }
 
@@ -253,7 +253,7 @@ impl FileCreateBuilder {
         let apc = plist.get_attr_phase_change()?;
         builder.attr_phase_change(apc.max_compact, apc.min_dense);
         builder.attr_creation_order(plist.get_attr_creation_order()?);
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         {
             builder.file_space_page_size(plist.get_file_space_page_size()?);
             builder.file_space_strategy(plist.get_file_space_strategy()?);
@@ -341,7 +341,7 @@ impl FileCreateBuilder {
         self
     }
 
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     /// Sets the file space page size.
     ///
     /// The minimum size is 512. Setting a value less than 512 will result in
@@ -352,7 +352,7 @@ impl FileCreateBuilder {
         self
     }
 
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     /// Sets the file space handling strategy and persisting free-space values.
     ///
     /// This setting cannot be changed for the life of the file.
@@ -396,7 +396,7 @@ impl FileCreateBuilder {
         if let Some(v) = self.attr_creation_order {
             h5try!(H5Pset_attr_creation_order(id, v.bits() as _));
         }
-        #[cfg(feature = "1.10.1")]
+        #[cfg(all(feature = "1.10.1", feature = "link"))]
         {
             if let Some(v) = self.file_space_page_size {
                 h5try!(H5Pset_file_space_page_size(id, v as _));
@@ -505,13 +505,13 @@ impl FileCreate {
     }
 
     #[doc(hidden)]
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn get_file_space_page_size(&self) -> Result<u64> {
         h5get!(H5Pget_file_space_page_size(self.id()): hsize_t).map(|x| x as _)
     }
 
     #[doc(hidden)]
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn get_file_space_strategy(&self) -> Result<FileSpaceStrategy> {
         let (strategy, persist, threshold) =
             h5get!(H5Pget_file_space_strategy(self.id()): H5F_fspace_strategy_t, hbool_t, hsize_t)?;
@@ -599,13 +599,13 @@ impl FileCreate {
     }
 
     /// Retrieves the file space page size.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn file_space_page_size(&self) -> u64 {
         self.get_file_space_page_size().unwrap_or(0)
     }
 
     /// Retrieves the file space handling strategy.
-    #[cfg(feature = "1.10.1")]
+    #[cfg(all(feature = "1.10.1", feature = "link"))]
     pub fn file_space_strategy(&self) -> FileSpaceStrategy {
         self.get_file_space_strategy().unwrap_or_else(|_| FileSpaceStrategy::default())
     }

--- a/hdf5/src/lib.rs
+++ b/hdf5/src/lib.rs
@@ -81,7 +81,7 @@ mod export {
     pub mod dataset {
         #[cfg(feature = "1.10.5")]
         pub use crate::hl::chunks::ChunkInfo;
-        #[cfg(feature = "1.14.0")]
+        #[cfg(all(feature = "1.14.0", feature = "link"))]
         pub use crate::hl::chunks::ChunkInfoRef;
         pub use crate::hl::dataset::{Chunk, Dataset, DatasetBuilder};
         pub use crate::hl::plist::dataset_access::*;

--- a/hdf5/src/sys/runtime.rs
+++ b/hdf5/src/sys/runtime.rs
@@ -355,9 +355,10 @@ pub enum H5F_close_degree_t {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum H5F_libver_t {
     H5F_LIBVER_ERROR = -1,
+    #[default]
     H5F_LIBVER_EARLIEST = 0,
     H5F_LIBVER_V18 = 1,
     H5F_LIBVER_V110 = 2,
@@ -425,8 +426,9 @@ pub const H5FD_LOG_ALL: u64 = H5FD_LOG_LOC_IO
     | H5FD_LOG_META_IO;
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum H5F_fspace_strategy_t {
+    #[default]
     H5F_FSPACE_STRATEGY_FSM_AGGR = 0,
     H5F_FSPACE_STRATEGY_PAGE = 1,
     H5F_FSPACE_STRATEGY_AGGR = 2,
@@ -576,7 +578,7 @@ pub struct H5O_info2_t {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct H5O_token_t {
     pub __data: [u8; 16],
 }


### PR DESCRIPTION
## Summary
- Add missing trait implementations (Default, PartialEq, Eq) to runtime.rs types
- Fix `hdf5_sys::` references in standard.rs to use `crate::sys`
- Gate HDF5 1.10.0+ APIs with `feature="link"` to disable them in runtime-loading mode

## Changes
These version-gated APIs are disabled in runtime-loading mode:
- Virtual dataset APIs (H5Pget_virtual_*, H5Pset_virtual_*)
- Chunk options (H5Pget_chunk_opts, H5Pset_chunk_opts)
- File space strategy APIs
- MDC logging/image config APIs
- H5Dchunk_iter (1.14.0+)

These APIs are not implemented in runtime.rs and are not needed for tensor4all-rs.

## Test plan
- [x] `cargo check --no-default-features --features "runtime-loading,complex"` compiles
- [x] `cargo clippy --workspace` passes
- [x] `cargo test --workspace` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)