### PR TITLE
fix: auto-initialize HDF5 library in runtime-loading mode

### DIFF
--- a/hdf5/src/globals.rs
+++ b/hdf5/src/globals.rs
@@ -50,7 +50,11 @@ macro_rules! link_hid {
 #[cfg(all(feature = "runtime-loading", not(feature = "link")))]
 macro_rules! link_hid {
     ($rust_name:ident, $c_name:path) => {
-        pub static $rust_name: LazyLock<hid_t> = LazyLock::new(|| $c_name());
+        pub static $rust_name: LazyLock<hid_t> = LazyLock::new(|| {
+            // Ensure the library is initialized
+            LazyLock::force(&crate::sync::LIBRARY_INIT);
+            $c_name()
+        });
     };
 }
 

--- a/hdf5/src/hl/file.rs
+++ b/hdf5/src/hl/file.rs
@@ -507,7 +507,7 @@ pub mod tests {
     }
 
     fn rc(id: hid_t) -> Result<hsize_t> {
-        h5call!(hdf5_sys::h5i::H5Iget_ref(id)).map(|x| x as _)
+        h5call!(crate::sys::h5i::H5Iget_ref(id)).map(|x| x as _)
     }
 
     #[test]

--- a/hdf5/src/hl/location.rs
+++ b/hdf5/src/hl/location.rs
@@ -429,7 +429,7 @@ pub mod tests {
     pub fn test_location_info() {
         let new_file = |path| {
             cfg_if::cfg_if! {
-                if #[cfg(feature = "1.10.2")] {
+                if #[cfg(all(feature = "1.10.2", feature = "link"))] {
                     File::with_options().with_fapl(|p| p.libver_v110()).create(path)
                 } else {
                     File::create(path)
@@ -445,7 +445,7 @@ pub mod tests {
                 assert_eq!(info.num_links, 1);
                 assert_eq!(info.loc_type, LocationType::Group);
                 cfg_if::cfg_if! {
-                    if #[cfg(feature = "1.10.2")] {
+                    if #[cfg(all(feature = "1.10.2", feature = "link"))] {
                         assert!(info.btime > 0);
                     } else {
                         assert_eq!(info.btime, 0);
@@ -482,7 +482,7 @@ pub mod tests {
                 assert_eq!(info.loc_type, LocationType::Dataset);
                 assert!(info.ctime > 0);
                 cfg_if::cfg_if! {
-                    if #[cfg(feature = "1.10.2")] {
+                    if #[cfg(all(feature = "1.10.2", feature = "link"))] {
                         assert!(info.btime > 0);
                     } else {
                         assert_eq!(info.btime, 0);

--- a/hdf5/src/lib.rs
+++ b/hdf5/src/lib.rs
@@ -238,6 +238,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg(feature = "link")]
     fn library_version_eq_compile_version() {
         use crate::sys::Version;
         let (major, minor, micro) = library_version();

--- a/hdf5/src/sync.rs
+++ b/hdf5/src/sync.rs
@@ -8,6 +8,14 @@ thread_local! {
 }
 
 pub(crate) static LIBRARY_INIT: LazyLock<()> = LazyLock::new(|| {
+    // In runtime-loading mode, initialize the library first
+    #[cfg(all(feature = "runtime-loading", not(feature = "link")))]
+    {
+        if !crate::sys::is_initialized() {
+            crate::sys::init(None).expect("Failed to initialize HDF5 library");
+        }
+    }
+
     let _guard = crate::sys::LOCK.lock();
     unsafe {
         // Ensure hdf5 does not invalidate handles which might

--- a/hdf5/src/sys/runtime.rs
+++ b/hdf5/src/sys/runtime.rs
@@ -1238,7 +1238,7 @@ hdf5_function!(
     ) -> herr_t
 );
 hdf5_function!(
-    H5Literate,
+    H5Literate1,
     fn(
         grp_id: hid_t,
         idx_type: H5_index_t,
@@ -1248,6 +1248,19 @@ hdf5_function!(
         op_data: *mut c_void,
     ) -> herr_t
 );
+
+/// Alias for backwards compatibility (H5Literate was renamed to H5Literate1 in HDF5 1.12+)
+#[inline]
+pub unsafe fn H5Literate(
+    grp_id: hid_t,
+    idx_type: H5_index_t,
+    order: H5_iter_order_t,
+    idx: *mut hsize_t,
+    op: H5L_iterate_t,
+    op_data: *mut c_void,
+) -> herr_t {
+    H5Literate1(grp_id, idx_type, order, idx, op, op_data)
+}
 hdf5_function!(
     H5Literate2,
     fn(


### PR DESCRIPTION
## Summary

- Add auto-initialization in `sync.rs` for runtime-loading mode
- Initialize library when accessing globals in runtime-loading mode  
- Use `H5Literate1` for HDF5 2.0 compatibility (`H5Literate` was renamed)
- Fix test to use `crate::sys` instead of `hdf5_sys`
- Gate version-specific test assertions on `link` feature
- Skip `library_version_eq_compile_version` test in runtime-loading mode

## Test plan

- [x] `cargo test --workspace` (link mode) - all tests pass
- [x] `cargo test -p tensor4all-hdf5-ffi --no-default-features --features "runtime-loading,complex"` - 102 tests pass
- [x] Integration test with tensor4all-rs (`cargo test -p tensor4all-hdf5`) - all tests pass

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)